### PR TITLE
Correct evaluation order of FinderAction#setSelected

### DIFF
--- a/lib/page/finder_action.js
+++ b/lib/page/finder_action.js
@@ -35,7 +35,7 @@ class FinderAction {
     return `(elements)=>{ for(let i = 0; i < elements.length; i++){ elements[i].checked = ${bool}; } }`
   }
   static setSelected(bool){
-    return `(elements)=>{ elements && elements[0].selected = ${bool} }`
+    return `(elements)=>{ elements && (elements[0].selected = ${bool}); }`
   }
 
   ////// instance methods //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* `Invalid left-hand side in assignment` occurred before this change.